### PR TITLE
fix: Add error handling to chart feature

### DIFF
--- a/nifty.py
+++ b/nifty.py
@@ -82,8 +82,11 @@ if run:
         selected_stocks = st.multiselect("Select stocks to view charts", options=df['Stock'].tolist())
         if selected_stocks:
             for stock_symbol in selected_stocks:
-                stock_data = yf.Ticker(f"{stock_symbol}.NS").history(period="6mo")
-                st.line_chart(stock_data['Close'])
+                try:
+                    stock_data = yf.Ticker(f"{stock_symbol}.NS").history(period="6mo")
+                    st.line_chart(stock_data['Close'])
+                except Exception as e:
+                    st.warning(f"Could not fetch chart for {stock_symbol}. Error: {e}")
     else:
         st.warning("No NIFTY stocks meet today's criteria. Try again later.")
     st.write(f"Analyzed {len(allc)} stocks that passed MA/volume/volatility rules.")

--- a/streamlit.log
+++ b/streamlit.log
@@ -1,9 +1,2 @@
 
 Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.
-
-
-  You can now view your Streamlit app in your browser.
-
-  Local URL: http://localhost:8502
-  Network URL: http://192.168.0.2:8502
-  External URL: http://34.46.237.233:8502


### PR DESCRIPTION
This commit fixes a bug in the historical price chart feature where the application would crash if it failed to fetch data for a selected stock.

The fix includes:
- Wrapping the `yfinance` API call in a `try...except` block.
- Displaying a user-friendly warning message with the error if the data for a specific stock cannot be fetched.

This ensures the application remains stable and provides better feedback to the user when an error occurs.